### PR TITLE
Fix typos & documentation inconsistencies

### DIFF
--- a/Documentation/2-Usage/2-Clock.md
+++ b/Documentation/2-Usage/2-Clock.md
@@ -37,7 +37,7 @@ If an app is using `Date()` or `[NSDate new]` as the mechanism for know what tim
 
 By instead relying on a `Clock`, altering the current notion of "time" becomes much simpler. Simply provide a `Clock` instance to the parts of your app that determine behavior, and then you have a way to *change the clock*. Just like you can walk over to a clock on the wall and manually change where its hands are pointing, you can do the same to a `Clock` instance.
 
-`Clock` provides several methods for constructing new or derivitive clocks with altered time:
+`Clock` provides several methods for constructing new or derivative clocks with altered time:
 
 ```swift
 // this creates a Clock that is always 42 seconds ahead of the system clock

--- a/Documentation/2-Usage/3-Value.md
+++ b/Documentation/2-Usage/3-Value.md
@@ -4,7 +4,7 @@
 
 A more colloquial definition might be: "If you can point to it on a calendar or clock, it's a `Value`".
 
-In order to accomplish this, `Value` defines two generic parameters, called `Smallest` and `Largest`. These parameters must be `Unit`-conforming types, of which there are current 8: `Era`, `Year`, `Month`, `Day`, `Hour`, `Minute`, `Second`, `Nanosecond`.
+In order to accomplish this, `Value` defines two generic parameters, called `Smallest` and `Largest`. These parameters must be `Unit`-conforming types, of which there are currently 8: `Era`, `Year`, `Month`, `Day`, `Hour`, `Minute`, `Second`, `Nanosecond`.
 
 For example, a `Value<Day, Era>` is value that represents *all calendar components* in the `Day ... Era` range, namely `Day`, `Month`, `Year`, and `Era`.
 

--- a/Sources/Time/1. Agnostic Types/Epoch.swift
+++ b/Sources/Time/1. Agnostic Types/Epoch.swift
@@ -18,10 +18,10 @@ public struct Epoch: Hashable {
         return lhs.offsetFromReferenceDate == rhs.offsetFromReferenceDate
     }
 
-    /// The Reference epoch (rooted at 1 Jan 2001 00:00:00 UTC)
+    /// The Reference epoch (rooted at 1 Jan 2001 00:00:00 UTC).
     public static let reference = Epoch(0)
 
-    /// The Unix epoch (rooted at 1 Jan 1970 00:00:00 UTC)
+    /// The Unix epoch (rooted at 1 Jan 1970 00:00:00 UTC).
     public static let unix = Epoch(-SISeconds.secondsBetweenUnixAndReferenceEpochs)
     
     internal let offsetFromReferenceDate: SISeconds

--- a/Sources/Time/1. Agnostic Types/Instant.swift
+++ b/Sources/Time/1. Agnostic Types/Instant.swift
@@ -18,22 +18,22 @@ import Foundation
 /// An `Instant` is an instantaneous point in time, relative to an `Epoch`.
 public struct Instant: Hashable, Comparable {
 
-    /// Determine if two Instants are equivalent
+    /// Determine if two Instants are equivalent.
     public static func ==(lhs: Instant, rhs: Instant) -> Bool {
         return lhs.intervalSinceReferenceEpoch == rhs.intervalSinceReferenceEpoch
     }
 
-    /// Determine if one Instant occurs before another Instant
+    /// Determine if one Instant occurs before another Instant.
     public static func <(lhs: Instant, rhs: Instant) -> Bool {
         return lhs.intervalSinceReferenceEpoch < rhs.intervalSinceReferenceEpoch
     }
 
-    /// Determine the number of seconds between two Instants
+    /// Determine the number of seconds between two Instants.
     public static func -(lhs: Instant, rhs: Instant) -> SISeconds {
         return lhs.intervalSinceReferenceEpoch - rhs.intervalSinceReferenceEpoch
     }
 
-    /// Apply an offset in seconds to an Instant
+    /// Apply an offset in seconds to an Instant.
     public static func +(lhs: Instant, rhs: SISeconds) -> Instant {
         return Instant(interval: lhs.intervalSinceEpoch + rhs, since: lhs.epoch)
     }

--- a/Sources/Time/2. Calendar Core/Region.swift
+++ b/Sources/Time/2. Calendar Core/Region.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// A `Region` contains all of the information necessary to refer to a user's preferences for expression calendrical values.
+/// A `Region` contains all of the information necessary to refer to a user's preferences for expressing calendrical values.
 ///
 /// It contains:
 /// - a `Calendar` value, which describes their preferred system for measuring time

--- a/Sources/Time/3. Clock/Clock+CurrentValues.swift
+++ b/Sources/Time/3. Clock/Clock+CurrentValues.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension Clock {
     
-    /// Retrieve the current `Instant` shown on the `Clock`
+    /// Retrieve the current `Instant` shown on the `Clock`.
     func now() -> Instant { return thisInstant() }
     
     /// Retrieve the current `Absolute` calendrical value, accurate down to the specified unit.
@@ -20,28 +20,28 @@ public extension Clock {
     func tomorrow() -> Absolute<Day> { return this().adding(days: 1) }
     func yesterday() -> Absolute<Day> { return this().subtracting(days: 1) }
     
-    /// Retrieve the current calendar era of the `Clock`
+    /// Retrieve the current calendar era of the `Clock`.
     func thisEra() -> Absolute<Era> { return this() }
     
-    /// Retrieve the current calendar year of the `Clock`
+    /// Retrieve the current calendar year of the `Clock`.
     func thisYear() -> Absolute<Year> { return this() }
     
-    /// Retrieve the current calendar month of the `Clock`
+    /// Retrieve the current calendar month of the `Clock`.
     func thisMonth() -> Absolute<Month> { return this() }
     
-    /// Retrieve the current calendar day of the `Clock`
+    /// Retrieve the current calendar day of the `Clock`.
     func thisDay() -> Absolute<Day> { return this() }
     
-    /// Retrieve the current calendar hour of the `Clock`
+    /// Retrieve the current calendar hour of the `Clock`.
     func thisHour() -> Absolute<Hour> { return this() }
     
-    /// Retrieve the current calendar minute of the `Clock`
+    /// Retrieve the current calendar minute of the `Clock`.
     func thisMinute() -> Absolute<Minute> { return this() }
     
-    /// Retrieve the current calendar second of the `Clock`
+    /// Retrieve the current calendar second of the `Clock`.
     func thisSecond() -> Absolute<Second> { return this() }
     
-    /// Retrieve the current calendar nanosecond of the `Clock`
+    /// Retrieve the current calendar nanosecond of the `Clock`.
     func thisNanosecond() -> Absolute<Nanosecond> { return this() }
     
     func nextYear() -> Absolute<Year> { return this().adding(years: 1) }

--- a/Sources/Time/3. Clock/Clock.swift
+++ b/Sources/Time/3. Clock/Clock.swift
@@ -41,14 +41,14 @@ public class Clock {
         self.init(implementation: SystemClock(), region: region)
     }
     
-    /// Create a clock with a custom start time and flow rate
+    /// Create a clock with a custom start time and flow rate.
     ///
     /// - Parameters:
-    ///   - referenceDate: The instanteous "now" from which the clock will start counting
+    ///   - referenceDate: The instanteous "now" from which the clock will start counting.
     ///   - rate: The rate at which time progresses in the clock, relative to the supplied calendar.
     ///     - `1.0` (the default) means one second on the system clock correlates to a second passing in the clock.
-    ///     - `2.0` would mean that every second elapsing on the system clock would be 2 seconds on this clock (ie, time progresses twice as fast)
-    ///   - region: The Region in which calendar Values are produced
+    ///     - `2.0` would mean that every second elapsing on the system clock would be 2 seconds on this clock (ie, time progresses twice as fast).
+    ///   - region: The Region in which calendar Values are produced.
     public convenience init(startingFrom referenceInstant: Instant, rate: Double = 1.0, region: Region = .autoupdatingCurrent) {
         guard rate > 0.0 else { fatalError("Clocks can only count forwards") }
         
@@ -57,21 +57,21 @@ public class Clock {
     }
     
     
-    /// Create a clock with a custom start time and flow rate
+    /// Create a clock with a custom start time and flow rate.
     ///
     /// - Parameters:
-    ///   - referenceEpoch: The instanteous "now" from which the clock will start counting
+    ///   - referenceEpoch: The instanteous "now" from which the clock will start counting.
     ///   - rate: The rate at which time progresses in the clock.
     ///     - `1.0` (the default) means one second on the system clock correlates to a second passing in the clock.
-    ///     - `2.0` would mean that every second elapsing on the system clock would be 2 seconds on this clock (ie, time progresses twice as fast)
-    ///   - region: The Region in which calendar Values are produced           
+    ///     - `2.0` would mean that every second elapsing on the system clock would be 2 seconds on this clock (ie, time progresses twice as fast).
+    ///   - region: The Region in which calendar Values are produced.
     public convenience init(startingFrom referenceEpoch: Epoch, rate: Double = 1.0, region: Region = .autoupdatingCurrent) {
         let referenceInstant = Instant(interval: 0, since: referenceEpoch)
         self.init(startingFrom: referenceInstant, rate: rate, region: region)
     }
     
     
-    /// Retrieve the current instant
+    /// Retrieve the current instant.
     ///
     /// - Returns: An `Instant` representing the current time on the clock.
     public func thisInstant() -> Instant {
@@ -79,20 +79,20 @@ public class Clock {
     }
     
     
-    /// Offset a clock
+    /// Offset a clock.
     ///
-    /// - Parameter by: A `TimeInterval` by which to create an offseted clock
-    /// - Returns: A new `Clock` that is offset by the specified `TimeInterval` from the receiver
+    /// - Parameter by: A `TimeInterval` by which to create an offseted clock.
+    /// - Returns: A new `Clock` that is offset by the specified `TimeInterval` from the receiver.
     public func offset(by: TimeInterval) -> Clock {
         let offset = OffsetClock(offset: by, from: impl)
         return Clock(implementation: offset, region: region)
     }
     
     
-    /// Convert a clock to a new time zone
+    /// Convert a clock to a new time zone.
     ///
-    /// - Parameter timeZone: The `TimeZone` of the new `Clock`
-    /// - Returns: A new `Clock` that reports values in the specified `TimeZone`
+    /// - Parameter timeZone: The `TimeZone` of the new `Clock`.
+    /// - Returns: A new `Clock` that reports values in the specified `TimeZone`.
     public func converting(to timeZone: TimeZone) -> Clock {
         if timeZone == self.timeZone { return self }
         let newRegion = Region(calendar: region.calendar, timeZone: timeZone, locale: region.locale)

--- a/Sources/Time/4. Values/Value+Components.swift
+++ b/Sources/Time/4. Values/Value+Components.swift
@@ -9,31 +9,31 @@ import Foundation
 
 public extension Absolute where Smallest: LTOEEra, Largest: GTOEEra {
     
-    /// Retrieve the numeric era of an absolute calendrical value
+    /// Retrieve the numeric era of an absolute calendrical value.
     var era: Int { return dateComponents.era.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have an era value") }
 }
 
 public extension Absolute where Smallest: LTOEYear, Largest: GTOEYear {
     
-    /// Retrieve the numeric year of an absolute calendrical value
+    /// Retrieve the numeric year of an absolute calendrical value.
     var year: Int { return dateComponents.year.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have a year value") }
 }
 
 public extension Value where Smallest: LTOEMonth, Largest: GTOEMonth {
     
-    /// Retrieve the numeric month of an absolute calendrical value
+    /// Retrieve the numeric month of an absolute calendrical value.
     var month: Int { return dateComponents.month.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have a month value") }
 }
 
 public extension Value where Smallest: LTOEDay, Largest: GTOEDay {
     
-    /// Retrieve the numeric day of an absolute calendrical value
+    /// Retrieve the numeric day of an absolute calendrical value.
     var day: Int { return dateComponents.day.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have a day value") }
 }
 
 public extension Value where Smallest: LTOEHour, Largest: GTOEHour {
     
-    /// Retrieve the numeric hour of an absolute calendrical value
+    /// Retrieve the numeric hour of an absolute calendrical value.
     var hour: Int { return dateComponents.hour.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have an hour value") }
 }
 
@@ -45,12 +45,12 @@ public extension Value where Smallest: LTOEMinute, Largest: GTOEMinute {
 
 public extension Value where Smallest: LTOESecond, Largest: GTOESecond {
     
-    /// Retrieve the numeric second of an absolute calendrical value
+    /// Retrieve the numeric second of an absolute calendrical value.
     var second: Int { return dateComponents.second.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have a second value") }
 }
 
 public extension Value where Smallest: LTOENanosecond, Largest: GTOENanosecond {
     
-    /// Retrieve the numeric nanosecond of an absolute calendrical value
+    /// Retrieve the numeric nanosecond of an absolute calendrical value.
     var nanosecond: Int { return dateComponents.nanosecond.unwrap("A Value<\(Smallest.self), \(Largest.self)> must have a nanosecond value") }
 }

--- a/Sources/Time/4. Values/Value+Initializers.swift
+++ b/Sources/Time/4. Values/Value+Initializers.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Value+Initializers.swift
 //  
 //
 //  Created by Dave DeLong on 11/9/19.

--- a/Sources/Time/4. Values/Value.swift
+++ b/Sources/Time/4. Values/Value.swift
@@ -79,7 +79,7 @@ extension Value: Equatable {
     
     /// Determine if two `Values` are equal.
     ///
-    /// Two `Values` are equal if they have the same `Region` and represent the same calendrical components
+    /// Two `Values` are equal if they have the same `Region` and represent the same calendrical components.
     /// - Parameter lhs: a `Value`
     /// - Parameter rhs: a `Value`
     public static func ==(lhs: Value, rhs: Value) -> Bool {

--- a/Sources/Time/4. Values/ValueSequence.swift
+++ b/Sources/Time/4. Values/ValueSequence.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ValueSequence.swift
 //  
 //
 //  Created by Dave DeLong on 10/5/19.

--- a/Sources/Time/4. Values/ValueSequence.swift
+++ b/Sources/Time/4. Values/ValueSequence.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-/// A `Sequence` of `Absolute` calendar values
+/// A `Sequence` of `Absolute` calendar values.
 public struct AbsoluteValueSequence<U: Unit>: Sequence {
     
     private let constructor: () -> AbsoluteValueIterator<U>
     
     /// Construct a sequence of `Absolute` calendar values starting from a specific value.
     /// - Parameters:
-    ///   - start: The starting `Absolute` calendar value
-    ///   - stride: The difference between subsequent calendar values
+    ///   - start: The starting `Absolute` calendar value.
+    ///   - stride: The difference between subsequent calendar values.
     ///   - keepGoing: A closure that is invoked to indicate whether the sequence should continue. This closure is invoked *before* the next value is generated.
     public init(start: Absolute<U>, stride: Difference<U, Era>, while keepGoing: @escaping (Absolute<U>) -> Bool) {
         constructor = { AbsoluteValueIterator(start: start, stride: stride, keepGoing: keepGoing)}
@@ -37,7 +37,7 @@ public struct AbsoluteValueSequence<U: Unit>: Sequence {
     ///
     /// - Note: This sequence iterates through values *up to and including* the upper bound of the range.
     /// - Parameters:
-    ///   - range: The `ClosedRange` of `Absolute` calendar values to iterate through
+    ///   - range: The `ClosedRange` of `Absolute` calendar values to iterate through.
     ///   - stride: The difference between subsequent calendar values.
     public init<S>(range: ClosedRange<Absolute<S>>, stride: Difference<U, Era>) {
         let lower = range.lowerBound
@@ -55,7 +55,7 @@ public struct AbsoluteValueSequence<U: Unit>: Sequence {
     
 }
 
-/// An iterator of `Absolute` calendar values
+/// An iterator of `Absolute` calendar values.
 public struct AbsoluteValueIterator<U: Unit>: IteratorProtocol {
     private let region: Region
     

--- a/Sources/Time/4. Values/ValueSequence.swift
+++ b/Sources/Time/4. Values/ValueSequence.swift
@@ -21,12 +21,12 @@ public struct AbsoluteValueSequence<U: Unit>: Sequence {
         constructor = { AbsoluteValueIterator(start: start, stride: stride, keepGoing: keepGoing)}
     }
     
-    /// Construct a seequence of `Absolute` calendar values that iterates through a definite range of values.
+    /// Construct a sequence of `Absolute` calendar values that iterates through a definite range of values.
     ///
     /// - Note: This sequence iterates through values *up to but not including* the upper bound of the range.
     /// - Parameters:
     ///   - range: The `Range` of `Absolute` calendar values to iterate through.
-    ///   - stride: The difference between susequent calendar values.
+    ///   - stride: The difference between subsequent calendar values.
     public init<S>(range: Range<Absolute<S>>, stride: Difference<U, Era>) {
         let lower = range.lowerBound
         let upper = range.upperBound.converting(to: lower.region)
@@ -38,7 +38,7 @@ public struct AbsoluteValueSequence<U: Unit>: Sequence {
     /// - Note: This sequence iterates through values *up to and including* the upper bound of the range.
     /// - Parameters:
     ///   - range: The `ClosedRange` of `Absolute` calendar values to iterate through
-    ///   - stride: The difference between susequent calendar values.
+    ///   - stride: The difference between subsequent calendar values.
     public init<S>(range: ClosedRange<Absolute<S>>, stride: Difference<U, Era>) {
         let lower = range.lowerBound
         let upper = range.upperBound.converting(to: lower.region)

--- a/Sources/Time/5. Absolute Values/Absolute+Conversion.swift
+++ b/Sources/Time/5. Absolute Values/Absolute+Conversion.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Absolute+Conversion.swift
 //  
 //
 //  Created by Dave DeLong on 2/12/20.

--- a/Sources/Time/5. Absolute Values/Absolute+Day.swift
+++ b/Sources/Time/5. Absolute Values/Absolute+Day.swift
@@ -47,13 +47,13 @@ public extension Absolute where Smallest: LTOEDay, Largest == Era {
     /// Returns the day of the month on which the receiver occurs.
     ///
     /// For example, given a value that represents "Halloween" (October 31st) on the gregorian calendar,
-    /// this property returns "31"
+    /// this property returns "31".
     var dayOfMonth: Int { return day }
     
-    /// Returns the day of the year on which the receiver occurs
+    /// Returns the day of the year on which the receiver occurs.
     ///
     /// For example, given a value that represents the first of February on the gregorian calendar,
-    /// this property returns "32"
+    /// this property returns "32".
     var dayOfYear: Int { return calendar.ordinality(of: .day, in: .year, for: approximateMidPoint.date)! }
     
     /// Returns the ordinal of the receiver's weekday within its month.

--- a/Sources/Time/5. Absolute Values/Absolute+Internal.swift
+++ b/Sources/Time/5. Absolute Values/Absolute+Internal.swift
@@ -1,5 +1,5 @@
 //
-//  Absolute.swift
+//  Absolute+Internal.swift
 //  Time
 //
 //  Created by Dave DeLong on 10/4/18.

--- a/Sources/Time/5. Absolute Values/Absolute+Truncation.swift
+++ b/Sources/Time/5. Absolute Values/Absolute+Truncation.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Absolute+Truncation.swift
 //  
 //
 //  Created by Dave DeLong on 2/12/20.

--- a/Sources/Time/5. Absolute Values/Absolute.swift
+++ b/Sources/Time/5. Absolute Values/Absolute.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Absolute.swift
 //  
 //
 //  Created by Dave DeLong on 2/12/20.

--- a/Sources/Time/5. Absolute Values/Absolute.swift
+++ b/Sources/Time/5. Absolute Values/Absolute.swift
@@ -29,7 +29,7 @@ extension Absolute {
         return startInstant..<endInstant
     }
     
-    /// Retrieve the first `Instant` known to occur within this `Value`
+    /// Retrieve the first `Instant` known to occur within this `Value`.
     public var firstInstant: Instant { return range.lowerBound }
     
     @available(*, unavailable, message: "It's impossible to know the last instant of a calendar value, just like it's impossible to know the last number before 1.0")

--- a/Sources/Time/Adjustment/Absolute+SafeAdjustment.swift
+++ b/Sources/Time/Adjustment/Absolute+SafeAdjustment.swift
@@ -51,7 +51,7 @@ public extension Absolute where Smallest: LTOEMonth, Largest == Era {
     /// Create a new `Value` by moving backward one month
     func previousMonth() -> Self { return subtracting(months: 1) }
     
-    /// Create a new `Value` by moving forwward some number of months
+    /// Create a new `Value` by moving forward some number of months
     /// - Parameter months: The number of months by which to move forward
     func adding(months: Int) -> Self { return applying(difference: .months(months)) }
     
@@ -81,7 +81,7 @@ public extension Absolute where Smallest: LTOEDay, Largest == Era {
     /// Create a new `Value` by moving backward one day
     func previousDay() -> Self { return subtracting(days: 1) }
     
-    /// Create a new `Value` by moving forwward some number of days
+    /// Create a new `Value` by moving forward some number of days
     /// - Parameter days: The number of days by which to move forward
     func adding(days: Int) -> Self { return applying(difference: .days(days)) }
     
@@ -99,7 +99,7 @@ public extension Absolute where Smallest: LTOEHour, Largest == Era {
     /// Create a new `Value` by moving backward one hour
     func previousHour() -> Self { return subtracting(hours: 1) }
     
-    /// Create a new `Value` by moving forwward some number of hours
+    /// Create a new `Value` by moving forward some number of hours
     /// - Parameter hours: The number of hours by which to move forward
     func adding(hours: Int) -> Self { return applying(difference: .hours(hours)) }
     
@@ -117,7 +117,7 @@ public extension Absolute where Smallest: LTOEMinute, Largest == Era {
     /// Create a new `Value` by moving backward one minute
     func previousMinute() -> Self { return subtracting(minutes: 1) }
     
-    /// Create a new `Value` by moving forwward some number of minutes
+    /// Create a new `Value` by moving forward some number of minutes
     /// - Parameter minutes: The number of minutes by which to move forward
     func adding(minutes: Int) -> Self { return applying(difference: .minutes(minutes)) }
     
@@ -135,7 +135,7 @@ public extension Absolute where Smallest: LTOESecond, Largest == Era {
     /// Create a new `Value` by moving backward one second
     func previousSecond() -> Self { return subtracting(seconds: 1) }
     
-    /// Create a new `Value` by moving forwward some number of seconds
+    /// Create a new `Value` by moving forward some number of seconds
     /// - Parameter seconds: The number of seconds by which to move forward
     func adding(seconds: Int) -> Self { return applying(difference: .seconds(seconds)) }
     
@@ -153,7 +153,7 @@ public extension Absolute where Smallest: LTOENanosecond, Largest == Era {
     /// Create a new `Value` by moving backward one nanosecond
     func previousNanosecond() -> Self { return subtracting(nanoseconds: 1) }
     
-    /// Create a new `Value` by moving forwward some number of nanoseconds
+    /// Create a new `Value` by moving forward some number of nanoseconds
     /// - Parameter nanoseconds: The number of nanoseconds by which to move forward
     func adding(nanoseconds: Int) -> Self { return applying(difference: .nanoseconds(nanoseconds)) }
     

--- a/Sources/Time/Adjustment/Absolute+SafeAdjustment.swift
+++ b/Sources/Time/Adjustment/Absolute+SafeAdjustment.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension Absolute {
     
-    /// Adjust an absolute value by applying a temporal delta value
+    /// Adjust an absolute value by applying a temporal delta value.
     ///
     /// - Parameter difference: The `Difference` that describes the difference between the receiver
     ///    and the produced value.
@@ -27,43 +27,43 @@ public extension Absolute {
 
 public extension Absolute where Smallest: LTOEYear, Largest == Era {
     
-    /// Create a new `Value` by moving forward one year
+    /// Create a new `Value` by moving forward one year.
     func nextYear() -> Self { return adding(years: 1) }
     
-    /// Create a new `Value` by moving backward one year
+    /// Create a new `Value` by moving backward one year.
     func previousYear() -> Self { return subtracting(years: 1) }
     
-    /// Create a new `Value` by moving forward some number of years
-    /// - Parameter years: The number of years by which to move forward
+    /// Create a new `Value` by moving forward some number of years.
+    /// - Parameter years: The number of years by which to move forward.
     func adding(years: Int) -> Self { return applying(difference: .years(years)) }
     
-    /// Create a new `Value` by moving backward some number of years
-    /// - Parameter years: The number of years by which to move backward
+    /// Create a new `Value` by moving backward some number of years.
+    /// - Parameter years: The number of years by which to move backward.
     func subtracting(years: Int) -> Self { return applying(difference: .years(-years)) }
     
 }
 
 public extension Absolute where Smallest: LTOEMonth, Largest == Era {
     
-    /// Create a new `Value` by moving forward one month
+    /// Create a new `Value` by moving forward one month.
     func nextMonth() -> Self { return adding(months: 1) }
     
-    /// Create a new `Value` by moving backward one month
+    /// Create a new `Value` by moving backward one month.
     func previousMonth() -> Self { return subtracting(months: 1) }
     
-    /// Create a new `Value` by moving forward some number of months
-    /// - Parameter months: The number of months by which to move forward
+    /// Create a new `Value` by moving forward some number of months.
+    /// - Parameter months: The number of months by which to move forward.
     func adding(months: Int) -> Self { return applying(difference: .months(months)) }
     
-    /// Create a new `Value` by moving backward some number of months
-    /// - Parameter months: The number of months by which to move backward
+    /// Create a new `Value` by moving backward some number of months.
+    /// - Parameter months: The number of months by which to move backward.
     func subtracting(months: Int) -> Self { return applying(difference: .months(-months)) }
     
 }
 
 public extension Absolute where Smallest: LTOEDay, Largest == Era {
     
-    /// Adjust the date to the beginning of the calendar's week
+    /// Adjust the date to the beginning of the calendar's week.
     func startOfWeek() -> Self {
         var s = self
         let targetWeekday = region.calendar.firstWeekday
@@ -75,90 +75,90 @@ public extension Absolute where Smallest: LTOEDay, Largest == Era {
         return s
     }
     
-    /// Create a new `Value` by moving forward one day
+    /// Create a new `Value` by moving forward one day.
     func nextDay() -> Self { return adding(days: 1) }
     
-    /// Create a new `Value` by moving backward one day
+    /// Create a new `Value` by moving backward one day.
     func previousDay() -> Self { return subtracting(days: 1) }
     
-    /// Create a new `Value` by moving forward some number of days
-    /// - Parameter days: The number of days by which to move forward
+    /// Create a new `Value` by moving forward some number of days.
+    /// - Parameter days: The number of days by which to move forward.
     func adding(days: Int) -> Self { return applying(difference: .days(days)) }
     
-    /// Create a new `Value` by moving backward some number of days
-    /// - Parameter days: The number of days by which to move backward
+    /// Create a new `Value` by moving backward some number of days.
+    /// - Parameter days: The number of days by which to move backward.
     func subtracting(days: Int) -> Self { return applying(difference: .days(-days)) }
     
 }
 
 public extension Absolute where Smallest: LTOEHour, Largest == Era {
     
-    /// Create a new `Value` by moving forward one hour
+    /// Create a new `Value` by moving forward one hour.
     func nextHour() -> Self { return adding(hours: 1) }
     
-    /// Create a new `Value` by moving backward one hour
+    /// Create a new `Value` by moving backward one hour.
     func previousHour() -> Self { return subtracting(hours: 1) }
     
-    /// Create a new `Value` by moving forward some number of hours
-    /// - Parameter hours: The number of hours by which to move forward
+    /// Create a new `Value` by moving forward some number of hours.
+    /// - Parameter hours: The number of hours by which to move forward.
     func adding(hours: Int) -> Self { return applying(difference: .hours(hours)) }
     
-    /// Create a new `Value` by moving backward some number of hours
-    /// - Parameter hours: The number of hours by which to move backward
+    /// Create a new `Value` by moving backward some number of hours.
+    /// - Parameter hours: The number of hours by which to move backward.
     func subtracting(hours: Int) -> Self { return applying(difference: .hours(-hours)) }
     
 }
 
 public extension Absolute where Smallest: LTOEMinute, Largest == Era {
     
-    /// Create a new `Value` by moving forward one minute
+    /// Create a new `Value` by moving forward one minute.
     func nextMinute() -> Self { return adding(minutes: 1) }
     
-    /// Create a new `Value` by moving backward one minute
+    /// Create a new `Value` by moving backward one minute.
     func previousMinute() -> Self { return subtracting(minutes: 1) }
     
-    /// Create a new `Value` by moving forward some number of minutes
-    /// - Parameter minutes: The number of minutes by which to move forward
+    /// Create a new `Value` by moving forward some number of minutes.
+    /// - Parameter minutes: The number of minutes by which to move forward.
     func adding(minutes: Int) -> Self { return applying(difference: .minutes(minutes)) }
     
-    /// Create a new `Value` by moving backward some number of minutes
-    /// - Parameter minutes: The number of minutes by which to move backward
+    /// Create a new `Value` by moving backward some number of minutes.
+    /// - Parameter minutes: The number of minutes by which to move backward.
     func subtracting(minutes: Int) -> Self { return applying(difference: .minutes(-minutes)) }
     
 }
 
 public extension Absolute where Smallest: LTOESecond, Largest == Era {
     
-    /// Create a new `Value` by moving forward one second
+    /// Create a new `Value` by moving forward one second.
     func nextSecond() -> Self { return adding(seconds: 1) }
     
-    /// Create a new `Value` by moving backward one second
+    /// Create a new `Value` by moving backward one second.
     func previousSecond() -> Self { return subtracting(seconds: 1) }
     
-    /// Create a new `Value` by moving forward some number of seconds
-    /// - Parameter seconds: The number of seconds by which to move forward
+    /// Create a new `Value` by moving forward some number of seconds.
+    /// - Parameter seconds: The number of seconds by which to move forward.
     func adding(seconds: Int) -> Self { return applying(difference: .seconds(seconds)) }
     
-    /// Create a new `Value` by moving backward some number of seconds
-    /// - Parameter seconds: The number of seconds by which to move backward
+    /// Create a new `Value` by moving backward some number of seconds.
+    /// - Parameter seconds: The number of seconds by which to move backward.
     func subtracting(seconds: Int) -> Self { return applying(difference: .seconds(-seconds)) }
     
 }
 
 public extension Absolute where Smallest: LTOENanosecond, Largest == Era {
     
-    /// Create a new `Value` by moving forward one nanosecond
+    /// Create a new `Value` by moving forward one nanosecond.
     func nextNanosecond() -> Self { return adding(nanoseconds: 1) }
     
-    /// Create a new `Value` by moving backward one nanosecond
+    /// Create a new `Value` by moving backward one nanosecond.
     func previousNanosecond() -> Self { return subtracting(nanoseconds: 1) }
     
-    /// Create a new `Value` by moving forward some number of nanoseconds
-    /// - Parameter nanoseconds: The number of nanoseconds by which to move forward
+    /// Create a new `Value` by moving forward some number of nanoseconds.
+    /// - Parameter nanoseconds: The number of nanoseconds by which to move forward.
     func adding(nanoseconds: Int) -> Self { return applying(difference: .nanoseconds(nanoseconds)) }
     
-    /// Create a new `Value` by moving backward some number of nanoseconds
-    /// - Parameter nanoseconds: The number of nanoseconds by which to move backward
+    /// Create a new `Value` by moving backward some number of nanoseconds.
+    /// - Parameter nanoseconds: The number of nanoseconds by which to move backward.
     func subtracting(nanoseconds: Int) -> Self { return applying(difference: .nanoseconds(-nanoseconds)) }
     
 }

--- a/Sources/Time/Adjustment/Absolute+SafeAdjustment.swift
+++ b/Sources/Time/Adjustment/Absolute+SafeAdjustment.swift
@@ -1,5 +1,5 @@
 //
-//  Adjustment+AbsoluteConvenience.swift
+//  Absolute+SafeAdjustment.swift
 //  Time
 //
 //  Created by Dave DeLong on 2/19/18.

--- a/Sources/Time/Adjustment/Absolute+UnsafeAdjustment.swift
+++ b/Sources/Time/Adjustment/Absolute+UnsafeAdjustment.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Absolute+UnsafeAdjustment.swift
 //  
 //
 //  Created by Dave DeLong on 11/9/19.

--- a/Sources/Time/Adjustment/AdjustmentError.swift
+++ b/Sources/Time/Adjustment/AdjustmentError.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  AdjustmentError.swift
 //  
 //
 //  Created by Dave DeLong on 11/9/19.

--- a/Sources/Time/Differences/Absolute+Difference.swift
+++ b/Sources/Time/Differences/Absolute+Difference.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Absolute+Difference.swift
 //  
 //
 //  Created by Dave DeLong on 2/4/20.

--- a/Sources/Time/Differences/Difference+Invalid.swift
+++ b/Sources/Time/Differences/Difference+Invalid.swift
@@ -1,5 +1,5 @@
 //
-//  Delta+Invalid, Eraswift
+//  Difference+Invalid.swift
 //  Time
 //
 //  Created by Dave DeLong on 2/19/18.

--- a/Sources/Time/Differences/Difference.swift
+++ b/Sources/Time/Differences/Difference.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-/// This is a nominal wrapper to an adjust to a Value
-/// This wrapper enables syntax like "today + .days(3)"
+/// This is a nominal wrapper to an adjust to a Value.
+/// This wrapper enables syntax like "today + .days(3)".
 public struct Difference<Smallest: Unit, Largest: Unit> {
     internal let dateComponents: DateComponents
     
@@ -29,7 +29,7 @@ public struct Difference<Smallest: Unit, Largest: Unit> {
 public extension Difference where Smallest: LTOEYear, Largest: GTOEYear {
     static func eras(_ value: Int) -> Difference { return self.init(value: value, unit: .era) }
 
-    /// Retrieve the number of eras in a calendrical difference
+    /// Retrieve the number of eras in a calendrical difference.
     var eras: Int {
         return dateComponents.era
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have an era value")
@@ -39,7 +39,7 @@ public extension Difference where Smallest: LTOEYear, Largest: GTOEYear {
 public extension Difference where Smallest: LTOEYear, Largest: GTOEYear {
     static func years(_ value: Int) -> Difference { return self.init(value: value, unit: .year) }
     
-    /// Retrieve the number of years in a calendrical difference
+    /// Retrieve the number of years in a calendrical difference.
     var years: Int {
         return dateComponents.year
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have a year value")
@@ -49,7 +49,7 @@ public extension Difference where Smallest: LTOEYear, Largest: GTOEYear {
 public extension Difference where Smallest: LTOEMonth, Largest: GTOEMonth {
     static func months(_ value: Int) -> Difference { return self.init(value: value, unit: .month) }
     
-    /// Retrieve the number of months in a calendrical difference
+    /// Retrieve the number of months in a calendrical difference.
     var months: Int {
         return dateComponents.month
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have a month value")
@@ -59,7 +59,7 @@ public extension Difference where Smallest: LTOEMonth, Largest: GTOEMonth {
 public extension Difference where Smallest: LTOEDay, Largest: GTOEDay {
     static func days(_ value: Int) -> Difference { return self.init(value: value, unit: .day) }
     
-    /// Retrieve the number of days in a calendrical difference
+    /// Retrieve the number of days in a calendrical difference.
     var days: Int
     {
         return dateComponents.day.unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have a day value")
@@ -69,7 +69,7 @@ public extension Difference where Smallest: LTOEDay, Largest: GTOEDay {
 public extension Difference where Smallest: LTOEHour, Largest: GTOEHour {
     static func hours(_ value: Int) -> Difference { return self.init(value: value, unit: .hour) }
     
-    /// Retrieve the number of hours in a calendrical difference
+    /// Retrieve the number of hours in a calendrical difference.
     var hours: Int {
         return dateComponents.hour
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have an hour value")
@@ -79,7 +79,7 @@ public extension Difference where Smallest: LTOEHour, Largest: GTOEHour {
 public extension Difference where Smallest: LTOEMinute, Largest: GTOEMinute {
     static func minutes(_ value: Int) -> Difference { return self.init(value: value, unit: .minute) }
     
-    /// Retrieve the number of minutes in a calendrical difference
+    /// Retrieve the number of minutes in a calendrical difference.
     var minutes: Int {
         return dateComponents.minute
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have a minute value")
@@ -89,7 +89,7 @@ public extension Difference where Smallest: LTOEMinute, Largest: GTOEMinute {
 public extension Difference where Smallest: LTOESecond, Largest: GTOESecond {
     static func seconds(_ value: Int) -> Difference { return self.init(value: value, unit: .second) }
     
-    /// Retrieve the number of seconds in a calendrical difference
+    /// Retrieve the number of seconds in a calendrical difference.
     var seconds: Int {
         return dateComponents.second
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have a second value")
@@ -99,7 +99,7 @@ public extension Difference where Smallest: LTOESecond, Largest: GTOESecond {
 public extension Difference where Smallest: LTOENanosecond, Largest: GTOENanosecond {
     static func nanoseconds(_ value: Int) -> Difference { return self.init(value: value, unit: .nanosecond) }
     
-    /// Retrieve the number of nanoseconds in a calendrical difference
+    /// Retrieve the number of nanoseconds in a calendrical difference.
     var nanoseconds: Int {
         return dateComponents.nanosecond
             .unwrap("A Difference<\(Smallest.self), \(Largest.self)> must have a nanosecond value")

--- a/Sources/Time/Formatting/AbsoluteFormatting.swift
+++ b/Sources/Time/Formatting/AbsoluteFormatting.swift
@@ -1,5 +1,5 @@
 //
-//  Absolute.swift
+//  AbsoluteFormatting.swift
 //  Time
 //
 //  Created by Dave DeLong on 5/17/18.

--- a/Sources/Time/Formatting/FormatTemplates.swift
+++ b/Sources/Time/Formatting/FormatTemplates.swift
@@ -1,5 +1,5 @@
 //
-//  Formats.swift
+//  FormatTemplates.swift
 //  Time
 //
 //  Created by Dave DeLong on 5/17/18.

--- a/Sources/Time/Internals/Calendar.swift
+++ b/Sources/Time/Internals/Calendar.swift
@@ -17,7 +17,7 @@ internal extension Calendar {
     /// Therefore, to accommodate this, the calendar needs to define how many
     /// SI Seconds are in each calendar-second.
     /// note: This does NOT affect how physics calculations are done (or velocities, etc)
-    /// because those are all defined relative to SI Seconds
+    /// because those are all defined relative to SI Seconds.
     var SISecondsPerSecond: Double { return 1.0 }
     
     /// For most calendars, the Era is not very relevant. For example "2019" is unambiguously

--- a/Sources/Time/Internals/Calendar.swift
+++ b/Sources/Time/Internals/Calendar.swift
@@ -14,7 +14,7 @@ internal extension Calendar {
     /// is the same as one SI Second. However, on Mars, the days are slightly longer,
     /// which means that dividing the slightly-longer day in to 86,400 slices results
     /// in "seconds" that are slightly longer than Earth seconds.
-    /// Therefore, to accomodate this, the calendar needs to define how many
+    /// Therefore, to accommodate this, the calendar needs to define how many
     /// SI Seconds are in each calendar-second.
     /// note: This does NOT affect how physics calculations are done (or velocities, etc)
     /// because those are all defined relative to SI Seconds

--- a/Sources/Time/Internals/DateFormatterCache.swift
+++ b/Sources/Time/Internals/DateFormatterCache.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  DateFormatterCache.swift
 //  
 //
 //  Created by Dave DeLong on 10/6/19.

--- a/Sources/Time/Parsing/Absolute+Parsing.swift
+++ b/Sources/Time/Parsing/Absolute+Parsing.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Absolute+Parsing.swift
 //  
 //
 //  Created by Dave DeLong on 2/4/20.

--- a/Sources/Time/Parsing/FormatDeduction.swift
+++ b/Sources/Time/Parsing/FormatDeduction.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  FormatDeduction.swift
 //  
 //
 //  Created by Dave DeLong on 2/4/20.

--- a/Sources/Time/Parsing/Parsing.swift
+++ b/Sources/Time/Parsing/Parsing.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Parsing.swift
 //  
 //
 //  Created by Dave DeLong on 2/4/20.

--- a/Sources/WIP-Calendar/Calendar.swift
+++ b/Sources/WIP-Calendar/Calendar.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Calendar.swift
 //  
 //
 //  Created by Dave DeLong on 2/11/20.

--- a/Sources/WIP-Relative/RelativeFormatting-1Unit.swift
+++ b/Sources/WIP-Relative/RelativeFormatting-1Unit.swift
@@ -1,5 +1,5 @@
 //
-//  RelativeFormatting.swift
+//  RelativeFormatting-1Unit.swift
 //  Time
 //
 //  Created by Dave DeLong on 5/18/18.

--- a/Sources/WIP-Relative/Value+RelativeFields.swift
+++ b/Sources/WIP-Relative/Value+RelativeFields.swift
@@ -1,5 +1,5 @@
 //
-//  ValueFields.swift
+//  Value+RelativeFields.swift
 //  
 //
 //  Created by Dave DeLong on 10/3/19.

--- a/Tests/TimeTests/ClockTests.swift
+++ b/Tests/TimeTests/ClockTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ClockTests.swift
 //  
 //
 //  Created by Dave DeLong on 10/28/19.

--- a/Tests/TimeTests/XCTestCase+Convenience.swift
+++ b/Tests/TimeTests/XCTestCase+Convenience.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  XCTestCase+Convenience.swift
 //  
 //
 //  Created by Dave DeLong on 10/28/19.


### PR DESCRIPTION
Commits:
* Fix small documentation typos in both Markdown and Swift documentation comments (91317a4)
* Fix mismatched filenames in Swift file header comments (65ebb2d)
* Add missing periods after Swift documentation comment summaries or parameter descriptions (a862f5d)

The contents of the third commit are potentially controversial, but going by what I'd seen from Apple's code documentation and the examples in the [Swift API design guidelines](https://swift.org/documentation/api-design-guidelines/), periods should end documentation sentences, including parameter descriptions.

Happy to drop out the last commit though, or make any other changes as needed.

Thanks!