### PR TITLE
Add nextDaylightSavingTimeTransition convenience method

### DIFF
--- a/Documentation/1-Overview/1-Motivation.md
+++ b/Documentation/1-Overview/1-Motivation.md
@@ -48,7 +48,7 @@ So for any developer who's wanting to see if "does this calendar value fall with
 
 The Foundation API also technically allows for some non-sensical and ambiguous calculations.
 
-For example, if you have an `NSDateComponents` of `{month: 2, day: 28, minute: 13}` (note: missing `year` and `hour`) and attempt to turn it into an `NSDate`, *you can*. However, the answer will be ambiguous. It will *probably* use the current year, but which hour will it pick? In my opinion, this level of ambiguity is undesireable and introduces too much confusion.
+For example, if you have an `NSDateComponents` of `{month: 2, day: 28, minute: 13}` (note: missing `year` and `hour`) and attempt to turn it into an `NSDate`, *you can*. However, the answer will be ambiguous. It will *probably* use the current year, but which hour will it pick? In my opinion, this level of ambiguity is undesirable and introduces too much confusion.
 
 `Time` solves this by using type safety to guarantee that all the information necessary to construct a date is provided up-front, and `throwing` an error for the cases where that can't be guaranteed, and the provided information is insufficient.
 

--- a/Documentation/1-Overview/2-Roadmap.md
+++ b/Documentation/1-Overview/2-Roadmap.md
@@ -35,7 +35,7 @@ Fill out base functionality and fully implement `Relative` values:
 
 - [ ] Format `Difference` values using `DateComponentsFormatter`
 - [ ] simple relative comparisons (`isBefore`, `isAfter`, etc)
-- [ ] rounding absolute values (adjust to the nearst 7 minutes, for example)
+- [ ] rounding absolute values (adjust to the nearest 7 minutes, for example)
 - [ ] public adjustment api (currently internal)
 - [x] formatting relative values
 - [x] initializing relative values from a `Foundation.Date`
@@ -95,11 +95,11 @@ There are various kinds of holiday calculations. In rough order of complexity (l
 - An ordinal weekday in a known month ("fourth Thursday of November")
 - An ordinal day of a year ("The 256th day of the year")
 - A day before/after a known day ("the day after Cyber Monday", "The day before Canadian Thanksgiving")
-- A weekday before/after a known day ("the monday after Thanksgiving")
-- A weekday of a specific week ("tuesday of the first full week of May")
-- A weekday before/after a relative event ("the monday after the DST jump")
-- A weekday before/after a celestial event ("the friday before the vernal equinox")
-- Easter ("the sunday following the Paschal full moon, on or after March 21")
+- A weekday before/after a known day ("the Monday after Thanksgiving")
+- A weekday of a specific week ("Tuesday of the first full week of May")
+- A weekday before/after a relative event ("the Monday after the DST jump")
+- A weekday before/after a celestial event ("the Friday before the vernal equinox")
+- Easter ("the Sunday following the Paschal full moon, on or after March 21")
 
 Questions...
 - Should any `Holiday` type be calendar-specific? "Christmas" is only ever interpreted relative to the Gregorian calendar.

--- a/Documentation/1-Overview/4-Inspiration.md
+++ b/Documentation/1-Overview/4-Inspiration.md
@@ -53,7 +53,7 @@ There are myriads of date/time convenience methods available on Github. *Time* d
     - Contains the definition of timezones, etc.
     - Probably not necessary, since there isn't an obvious need to replace `Foundation.TimeZone`
 - [`java.time.format`](https://docs.oracle.com/javase/8/docs/api/java/time/format/package-summary.html)
-    - Formating temporal objects into human-readable forms
+    - Formatting temporal objects into human-readable forms
     - Probably not necessary, since the Foundation-provided formatters are excellent in-and-of themselves
 
 ## Recurrence, Parsing, etc

--- a/Documentation/2-Usage/4-Adjusting.md
+++ b/Documentation/2-Usage/4-Adjusting.md
@@ -15,7 +15,7 @@ There are two fundamental categories of adjustments: Safe adjustments, and Unsaf
 
 Safe adjustments are *relative* adjustments. This means they typically involve starting with a known value, and then applying a relative difference. The example above is one such adjustment.
 
-These adjustments are "safe", because there is no reasonable way in which they will fail. For example, if I have a value representing a "day", then it will always be possible to find the preceeding or succeeding day.
+These adjustments are "safe", because there is no reasonable way in which they will fail. For example, if I have a value representing a "day", then it will always be possible to find the preceding or succeeding day.
 
 `Value` includes methods for performing safe adjustments (the `.adding(...)` and `.subtracting(...)` methods). As a convenience, it also includes overrides of the `+` and `-` operator for a more expressive syntax:
 

--- a/Sources/Time/1. Agnostic Types/SISeconds.swift
+++ b/Sources/Time/1. Agnostic Types/SISeconds.swift
@@ -13,8 +13,8 @@ import Foundation
 /// It supports fractional seconds, up to the precision allowed by `Double`.
 ///
 /// This type exists to ensure a proper distinction between "seconds as used in physics calculations"
-/// and "seconds as represented by a calendar". On Earth, there is typically a 1:1 correspondance between
-/// SI seconds and calendrical seconds. However, this correspondance is not *required*, and so a separate
+/// and "seconds as represented by a calendar". On Earth, there is typically a 1:1 correspondence between
+/// SI seconds and calendrical seconds. However, this correspondence is not *required*, and so a separate
 /// of representation is needed.
 ///
 /// - SeeAlso: [https://en.wikipedia.org/wiki/SI_base_unit](https://en.wikipedia.org/wiki/SI_base_unit)

--- a/Sources/Time/2. Calendar Core/Region.swift
+++ b/Sources/Time/2. Calendar Core/Region.swift
@@ -21,7 +21,7 @@ public struct Region: Hashable {
     /// The POSIX region: the Gregorian calendar in the UTC time zone, using the `en_US_POSIX` locale.
     public static let posix = Region(calendar: Calendar(identifier: .gregorian), timeZone: TimeZone(secondsFromGMT: 0)!, locale: Locale(identifier: "en_US_POSIX"))
     
-    /// The "autoupdating" current region. This Region will automatically track changes to the user's selected timeZone, calendar, and locale.
+    /// The "autoupdating" current region. This Region will automatically track changes to the user's selected time zone, calendar, and locale.
     public static let autoupdatingCurrent = Region(calendar: .autoupdatingCurrent, timeZone: .autoupdatingCurrent, locale: .autoupdatingCurrent)
     
     /// The `Calendar` used in this `Region`.

--- a/Sources/Time/3. Clock/Clock.swift
+++ b/Sources/Time/3. Clock/Clock.swift
@@ -44,7 +44,7 @@ public class Clock {
     /// Create a clock with a custom start time and flow rate.
     ///
     /// - Parameters:
-    ///   - referenceDate: The instanteous "now" from which the clock will start counting.
+    ///   - referenceDate: The instantaneous "now" from which the clock will start counting.
     ///   - rate: The rate at which time progresses in the clock, relative to the supplied calendar.
     ///     - `1.0` (the default) means one second on the system clock correlates to a second passing in the clock.
     ///     - `2.0` would mean that every second elapsing on the system clock would be 2 seconds on this clock (ie, time progresses twice as fast).
@@ -60,7 +60,7 @@ public class Clock {
     /// Create a clock with a custom start time and flow rate.
     ///
     /// - Parameters:
-    ///   - referenceEpoch: The instanteous "now" from which the clock will start counting.
+    ///   - referenceEpoch: The instantaneous "now" from which the clock will start counting.
     ///   - rate: The rate at which time progresses in the clock.
     ///     - `1.0` (the default) means one second on the system clock correlates to a second passing in the clock.
     ///     - `2.0` would mean that every second elapsing on the system clock would be 2 seconds on this clock (ie, time progresses twice as fast).
@@ -81,7 +81,7 @@ public class Clock {
     
     /// Offset a clock.
     ///
-    /// - Parameter by: A `TimeInterval` by which to create an offseted clock.
+    /// - Parameter by: A `TimeInterval` by which to create an offset clock.
     /// - Returns: A new `Clock` that is offset by the specified `TimeInterval` from the receiver.
     public func offset(by: TimeInterval) -> Clock {
         let offset = OffsetClock(offset: by, from: impl)

--- a/Sources/Time/3. Clock/Clock.swift
+++ b/Sources/Time/3. Clock/Clock.swift
@@ -111,6 +111,14 @@ public class Clock {
         // TODO: if the new calendar defines a different scaling of SI Seconds... ?
         return Clock(implementation: impl, region: newRegion)
     }
+    
+    
+    /// Retrieve the `Instant` of the next daylight saving time transition.
+    ///
+    /// - Parameter after: The `Instant` after which to find the next daylight saving time transition. If omitted, it will be assumed to be the current instant.
+    /// - Returns: The `Instant` of the next daylight saving time transition, or `nil` if the time zone does not currently observe daylight saving time.
+    public func nextDaylightSavingTimeTransition(after instant: Instant? = nil) -> Instant? {
+        let afterInstant = instant ?? now()
+        return timeZone.nextDaylightSavingTimeTransition(after: afterInstant.date).map(Instant.init)
+    }
 }
-
-

--- a/Sources/Time/4. Values/Value+Initializers.swift
+++ b/Sources/Time/4. Values/Value+Initializers.swift
@@ -53,7 +53,7 @@ extension Absolute {
 
 extension Value where Smallest == Year, Largest == Era {
     
-    /// Construct an `Aboslute<Year>` from the specified numeric components.
+    /// Construct an `Absolute<Year>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.
@@ -68,7 +68,7 @@ extension Value where Smallest == Year, Largest == Era {
 
 extension Value where Smallest == Month, Largest == Era {
     
-    /// Construct an `Aboslute<Month>` from the specified numeric components.
+    /// Construct an `Absolute<Month>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.
@@ -84,7 +84,7 @@ extension Value where Smallest == Month, Largest == Era {
 
 extension Value where Smallest == Day, Largest == Era {
     
-    /// Construct an `Aboslute<Day>` from the specified numeric components.
+    /// Construct an `Absolute<Day>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.
@@ -101,7 +101,7 @@ extension Value where Smallest == Day, Largest == Era {
 
 extension Value where Smallest == Hour, Largest == Era {
     
-    /// Construct an `Aboslute<Hour>` from the specified numeric components.
+    /// Construct an `Absolute<Hour>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.
@@ -119,7 +119,7 @@ extension Value where Smallest == Hour, Largest == Era {
 
 extension Value where Smallest == Minute, Largest == Era {
     
-    /// Construct an `Aboslute<Minute>` from the specified numeric components.
+    /// Construct an `Absolute<Minute>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.
@@ -138,7 +138,7 @@ extension Value where Smallest == Minute, Largest == Era {
 
 extension Value where Smallest == Second, Largest == Era {
     
-    /// Construct an `Aboslute<Second>` from the specified numeric components.
+    /// Construct an `Absolute<Second>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.
@@ -158,7 +158,7 @@ extension Value where Smallest == Second, Largest == Era {
 
 extension Value where Smallest == Nanosecond, Largest == Era {
     
-    /// Construct an `Aboslute<Nanosecond>` from the specified numeric components.
+    /// Construct an `Absolute<Nanosecond>` from the specified numeric components.
     /// - Parameters:
     ///   - region: The `Region` in which the components will be interpreted.
     ///   - era: The numeric `Era` value for the value. If omitted, it will assumed to be the "current" era.

--- a/Sources/Time/5. Absolute Values/Absolute+Day.swift
+++ b/Sources/Time/5. Absolute Values/Absolute+Day.swift
@@ -41,24 +41,24 @@ public extension Absolute where Smallest: LTOEDay, Largest == Era {
     
     /// Returns the numerical representation of the receiver's day of the week.
     ///
-    /// For the gregorian calendar, 1 = Sunday, 2 = Monday, ... 7 = Saturday
+    /// For the Gregorian calendar, 1 = Sunday, 2 = Monday, ... 7 = Saturday
     var dayOfWeek: Int { return calendar.component(.weekday, from: approximateMidPoint.date) }
     
     /// Returns the day of the month on which the receiver occurs.
     ///
-    /// For example, given a value that represents "Halloween" (October 31st) on the gregorian calendar,
+    /// For example, given a value that represents "Halloween" (October 31st) on the Gregorian calendar,
     /// this property returns "31".
     var dayOfMonth: Int { return day }
     
     /// Returns the day of the year on which the receiver occurs.
     ///
-    /// For example, given a value that represents the first of February on the gregorian calendar,
+    /// For example, given a value that represents the first of February on the Gregorian calendar,
     /// this property returns "32".
     var dayOfYear: Int { return calendar.ordinality(of: .day, in: .year, for: approximateMidPoint.date)! }
     
     /// Returns the ordinal of the receiver's weekday within its month.
     ///
-    /// For example, if the receiver falls on the second "Friday" of a month on the gregorian calendar,
-    /// then `dayOfWeek` returns `6` ("Friday"), and this property returns `2` (the second friday).
+    /// For example, if the receiver falls on the second "Friday" of a month on the Gregorian calendar,
+    /// then `dayOfWeek` returns `6` ("Friday"), and this property returns `2` (the second Friday).
     var dayOfWeekOrdinal: Int { return calendar.component(.weekdayOrdinal, from: approximateMidPoint.date) }
 }

--- a/Sources/Time/Adjustment/Adjustment.swift
+++ b/Sources/Time/Adjustment/Adjustment.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// An Adjustment is a way to mutate a Value in a calendrically safe way.
 /// Adjustments of this sort are typically "relative" adjustments, like adding or subtracting offsets,
-/// or finding the next or previous occurence of a particular event.
+/// or finding the next or previous occurrence of a particular event.
 internal struct Adjustment<IS: Unit, IL: Unit, OS: Unit, OL: Unit> {
     
     fileprivate let adjust: (Value<IS, IL>) -> Value<OS, OL>
@@ -20,7 +20,7 @@ internal struct Adjustment<IS: Unit, IL: Unit, OS: Unit, OL: Unit> {
     
 }
 
-/// An UnsafeAdjustment is a mutation to a Value that may result in a non-existant value.
+/// An UnsafeAdjustment is a mutation to a Value that may result in a non-existent value.
 /// For example, any attempt to *set* the value of a particular field is unsafe,
 /// because there is no guarantee that the specified value calendrically exists.
 /// A trivial demonstration would be attempting to set the day of February to 31; this should throw.

--- a/Tests/TimeTests/ClockTests.swift
+++ b/Tests/TimeTests/ClockTests.swift
@@ -79,5 +79,78 @@ class ClockTests: XCTestCase {
         
         XCTAssertEqual(elapsedTime.rawValue, 0.1, accuracy: 0.01) // 10% margin for error
     }
+}
+
+// MARK: - Next Daylight Saving Time Transition
+
+extension ClockTests {
+    
+    func testNextDSTTransitionForTimeZoneWithDST() {
+        let timeZone = TimeZone(identifier: "Europe/London")!
+        
+        let region = Region(
+            calendar: .autoupdatingCurrent,
+            timeZone: timeZone,
+            locale: .autoupdatingCurrent)
+        
+        let clock = Clock(region: region)
+        
+        let instant = clock.nextDaylightSavingTimeTransition()
+        XCTAssertNotNil(instant)
+        XCTAssertEqual(
+            instant?.intervalSinceEpoch.rawValue,
+            timeZone.nextDaylightSavingTimeTransition?.timeIntervalSinceReferenceDate)
+    }
+    
+    func testNextDSTTransitionNextYearForTimeZoneWithDST() {
+        let timeZone = TimeZone(identifier: "Europe/London")!
+        
+        let region = Region(
+            calendar: .autoupdatingCurrent,
+            timeZone: timeZone,
+            locale: .autoupdatingCurrent)
+        
+        let clock = Clock(region: region)
+        let instantNextYear = (clock.thisDay() + .years(1)).firstInstant
+        
+        let nextDSTSeconds = clock
+            .nextDaylightSavingTimeTransition(after: instantNextYear)?.intervalSinceEpoch.rawValue
+        
+        let expectedDSTSeconds = timeZone
+            .nextDaylightSavingTimeTransition(after: instantNextYear.date)?.timeIntervalSinceReferenceDate
+        
+        XCTAssertNotNil(nextDSTSeconds)
+        XCTAssertEqual(nextDSTSeconds, expectedDSTSeconds)
+    }
+    
+    func testNextDSTTransitionForTimeZoneWithoutDST() {
+        let timeZone = TimeZone(identifier: "Europe/Moscow")!
+
+        let region = Region(
+            calendar: .autoupdatingCurrent,
+            timeZone: timeZone,
+            locale: .autoupdatingCurrent)
+
+        let clock = Clock(region: region)
+        
+        XCTAssertNil(clock.nextDaylightSavingTimeTransition())
+    }
+    
+    func testNextDSTTransitionNextYearForTimeZoneWithoutDST() {
+        let timeZone = TimeZone(identifier: "Europe/Moscow")!
+
+        let region = Region(
+            calendar: .autoupdatingCurrent,
+            timeZone: timeZone,
+            locale: .autoupdatingCurrent)
+
+        let clock = Clock(region: region)
+        let instantNextYear = (clock.thisDay() + .years(1)).firstInstant
+        
+        let nextDSTSeconds = clock
+            .nextDaylightSavingTimeTransition(after: instantNextYear)?.intervalSinceEpoch.rawValue
+        
+        XCTAssertNil(nextDSTSeconds)
+    }
     
 }


### PR DESCRIPTION
Commits:
* Add a `nextDaylightSavingTimeTransition` convenience property to `Region`, with unit tests (e2a2b50)
* Fix more documentation typos by running Xcode spelling & grammar check over the Markdown & Swift files in the package [hopefully no more commits on this 😅] (9569f2e)

Keen to try and contribute to the library, but I hope I haven't misunderstood the concepts in `time` here by using an `Instant` to represent the next DST transition