### PR TITLE
Avoid performance penalty when performing assertions

### DIFF
--- a/Sources/Time/Internals/Assertions.swift
+++ b/Sources/Time/Internals/Assertions.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 
-internal func require(_ condition: @autoclosure () -> Bool, _ why: String, file: StaticString = #file, line: UInt = #line) {
+internal func require(_ condition: @autoclosure () -> Bool, _ why: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
     guard condition() == true else {
-        fatalError(why, file: file, line: line)
+        fatalError(why(), file: file, line: line)
     }
 }
 
 internal extension Optional {
     
-    func unwrap(_ why: String, file: StaticString = #file, line: UInt = #line) -> Wrapped {
+    func unwrap(_ why: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) -> Wrapped {
         guard let value = self else {
-            fatalError(why, file: file, line: line)
+            fatalError(why(), file: file, line: line)
         }
         return value
     }


### PR DESCRIPTION
I came up with a huge performance penalty while using this library in a collection view. `Optional.unwrap` is used in many parts and the `why` parameter is evaluated always, even if no error occurs. 

The concrete line that provoques the performance penalty is in `Absolute+SafeAdjustment.swift:20`, 
```swift
let newDate = $0.calendar.date(byAdding: diff, to: d).unwrap("Unable to add \(diff) to \($0)")
```
where the second value in the why message performs a fullFormat call on the date 

This fix avoids the issue by converting the assertion methods `why` parameter to an auto closure.