### PR TITLE
Added Chimes

### DIFF
--- a/Sources/Time/3. Clock/Clock+Chimes.swift
+++ b/Sources/Time/3. Clock/Clock+Chimes.swift
@@ -49,7 +49,7 @@ extension Clock {
         let interval = Difference<U, Era>(value: 1, unit: U.component)
         return Clock.IntervalChime(for: self,
                                    interval: interval,
-                                   startTime: self.this(),
+                                   startTime: nil,
                                    predicate: matches)
     }
     

--- a/Sources/Time/3. Clock/Clock+Chimes.swift
+++ b/Sources/Time/3. Clock/Clock+Chimes.swift
@@ -15,13 +15,18 @@ extension Clock {
     
     /// Sets up a repeating chime (ex: "every 5 minutes"), optionally starting at a time other than the present instant.
     ///
+    /// - Note: The first "chime" will not occur until *after* `interval` has passed beyond `startTime` (or
+    ///   the immediate present if `startTime` is `nil`).
+    ///
     /// - Parameters:
     ///   - interval: The amount of time that should elapse before the next chime occurs.
     ///   - startTime: The time to start counting at before the first chime occurs.
     /// - Returns: A publisher which publishes absolute time values at the moment of each chime.
-    public func chime<S, L>(every interval: Difference<S, L>,
-                            startingFrom startTime: Absolute<S>? = nil) -> Clock.IntervalChime<S> where S: Unit, L: Unit {
-        return Clock.IntervalChime<S>(clock: self)
+    public func chime<U>(every interval: Difference<U, Era>,
+                         startingFrom startTime: Absolute<U>? = nil) -> Clock.IntervalChime<U> where U: Unit {
+        return Clock.IntervalChime(for: self,
+                                   interval: interval,
+                                   startTime: startTime)
     }
     
     /// Sets up a repeating chime for each unit that matches the given closure.
@@ -40,12 +45,12 @@ extension Clock {
     ///   - time: A propspective time value.
     ///
     /// - Returns: A publisher which publishes absolute time values at the moment of each chime.
-    public func chime<U: Unit>(when matches: @escaping (_ time: Absolute<U>) -> Bool) -> AnyPublisher<Absolute<U>, Never> {
-        let startTime: Absolute<U> = self.this()
+    public func chime<U>(when matches: @escaping (_ time: Absolute<U>) -> Bool) -> Clock.IntervalChime<U> where U: Unit {
         let interval = Difference<U, Era>(value: 1, unit: U.component)
-        return chime(every: interval, startingFrom: startTime)
-           .filter(matches)
-           .eraseToAnyPublisher()
+        return Clock.IntervalChime(for: self,
+                                   interval: interval,
+                                   startTime: self.this(),
+                                   predicate: matches)
     }
     
     /// Sets up a single chime (ex: "at 12:00 PM").
@@ -56,7 +61,24 @@ extension Clock {
     ///
     /// - Returns: A publisher which publishes the current absolute time and then completes.
     public func chime<U>(at time: Absolute<U>) -> Clock.AbsoluteChime<U> where U: Unit {
-        return Clock.AbsoluteChime<U>(for: self, atFirstInstantOf: time)
+        return Clock.AbsoluteChime(for: self, firstInstantOf: time)
+    }
+    
+}
+
+private extension Value {
+    
+    /// Returns the `TimeInterval` (number of seconds) from this `Value` to the `next`.
+    ///
+    /// For example, May 5 at 3:02:26 and May 5 at 3:02:30 are 4 seconds apart. The opposite
+    /// would return a negative value.
+    func seconds(to next: Self) -> TimeInterval {
+        let now = self
+        let then = next
+        let nowSeconds = now.firstInstant.intervalSinceEpoch.rawValue
+        let thenSeconds = then.firstInstant.intervalSinceEpoch.rawValue
+        
+        return thenSeconds - nowSeconds
     }
     
 }
@@ -66,16 +88,100 @@ extension Clock {
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Clock {
     
+    public final class IntervalChimeSubscription<SubscriberType, Unit>: Subscription
+        where Unit: Time.Unit,
+        SubscriberType: Subscriber,
+        SubscriberType.Failure == Clock.IntervalChime<Unit>.Failure,
+        SubscriberType.Input == Clock.IntervalChime<Unit>.Output {
+        
+        private var subscriber: SubscriberType?
+        private let clock: Clock
+        private let predicate: (Absolute<Unit>) -> Bool
+        private let timer: DispatchSourceTimer
+        
+        init(subscriber: SubscriberType,
+             clock: Clock,
+             interval: Difference<Unit, Era>,
+             startingAt startTime: Absolute<Unit>?,
+             predicate: @escaping (_ time: Absolute<Unit>) -> Bool) {
+            self.subscriber = subscriber
+            self.clock = clock
+            self.predicate = predicate
+            
+            // start waiting...
+            self.timer = DispatchSource.makeTimerSource(flags: .strict)
+            timer.setEventHandler(handler: performChime)
+            let now: Absolute<Unit> = clock.this()
+            let start = startTime ?? now
+            
+            let secondsToStart = now.seconds(to: start)
+            let firstTick = start.applying(difference: interval)
+            let repeatInterval = start.seconds(to: firstTick)
+            
+            let rate = clock.rate
+            // First chime (deadline) happens after delay and first elapsed interval
+            timer.schedule(deadline: .now() + (secondsToStart / rate) + (repeatInterval / rate),
+                           repeating: (repeatInterval / rate))
+            timer.activate()
+        }
+        
+        private func performChime() {
+            let value: Absolute<Unit> = clock.this()
+            guard predicate(value) else { return }
+            _ = subscriber?.receive(value)
+        }
+        
+        public func request(_ demand: Subscribers.Demand) {
+            // We ignore this, since time doesn't care when we're looking.
+        }
+        
+        public func cancel() {
+            timer.cancel()
+            subscriber = nil
+        }
+    }
+    
+    /// A publisher which publishes repeatedly—each time a given `Clock` reads that a specified time interval
+    /// has elapsed.
     public struct IntervalChime<Unit>: Combine.Publisher where Unit: Time.Unit {
         
         public typealias Output = Absolute<Unit>
         public typealias Failure = Never
         
         /// The clock that the publisher watches for time events.
-        public let clock: Clock
+        public var clock: Clock
+        
+        /// The time interval between chimes.
+        public var interval: Difference<Unit, Era>
+        
+        /// The time at which to start chiming.
+        ///
+        /// If found to be `nil` when a subscriber requests values, then the present time is assumed.
+        public var startTime: Absolute<Unit>?
+        
+        /// A predicate to use which determines whether a time value will be published.
+        ///
+        /// Defaults to a closure that always returns `true`.
+        public var predicate: (Absolute<Unit>) -> Bool
+        
+        public init(for clock: Clock,
+                    interval: Difference<Unit, Era>,
+                    startTime: Absolute<Unit>?,
+                    predicate: @escaping (_ time: Absolute<Unit>) -> Bool = { _ in true }) {
+            self.clock = clock
+            self.interval = interval
+            self.startTime = startTime
+            self.predicate = predicate
+        }
         
         public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
-            _ = subscriber.receive(clock.this())
+            let subscription =
+                IntervalChimeSubscription(subscriber: subscriber,
+                                          clock: clock,
+                                          interval: interval,
+                                          startingAt: startTime,
+                                          predicate: predicate)
+            subscriber.receive(subscription: subscription)
         }
         
     }
@@ -86,32 +192,31 @@ extension Clock {
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Clock {
     
-    public final class AbsoluteChimeSubscription<SubscriberType, SmallestUnit>: Combine.Subscription
-        where SmallestUnit: Unit,
+    /// A subscription to a `Clock.AbsoluteChime`.
+    public final class AbsoluteChimeSubscription<SubscriberType, Unit>: Subscription
+        where Unit: Time.Unit,
         SubscriberType: Subscriber,
-        SubscriberType.Failure == Clock.AbsoluteChime<SmallestUnit>.Failure,
-        SubscriberType.Input == Clock.AbsoluteChime<SmallestUnit>.Output {
+        SubscriberType.Failure == Clock.AbsoluteChime<Unit>.Failure,
+        SubscriberType.Input == Clock.AbsoluteChime<Unit>.Output {
         
         private var subscriber: SubscriberType?
         private let clock: Clock
-        private let value: Absolute<SmallestUnit>
         private let timer: DispatchSourceTimer
         
-        init(subscriber: SubscriberType, clock: Clock, value: Absolute<SmallestUnit>) {
+        init(subscriber: SubscriberType, clock: Clock, value: Absolute<Unit>) {
             self.subscriber = subscriber
             self.clock = clock
-            self.value = value
             
             // start waiting...
             self.timer = DispatchSource.makeTimerSource(flags: .strict)
             timer.setEventHandler(handler: performChime)
-            let now: Absolute<SmallestUnit> = clock.this()
+            let now: Absolute<Unit> = clock.this()
             let then = value
-            let nowSeconds = now.firstInstant.intervalSinceEpoch.rawValue
-            let thenSeconds = then.firstInstant.intervalSinceEpoch.rawValue
+            let normalInterval = now.seconds(to: then)
             
             let rate = clock.rate
-            let difference = (thenSeconds - nowSeconds) / rate
+            let difference = (normalInterval) / rate
+            // Chime (deadline) happens after first elapsed interval
             timer.schedule(deadline: .now() + difference)
             timer.activate()
         }
@@ -132,17 +237,19 @@ extension Clock {
         }
     }
     
-    /// A publisher which fires exactly once and then completes.
-    public struct AbsoluteChime<Unit>: Combine.Publisher where Unit: Time.Unit {
+    /// A publisher which publishes exactly once—when a given `Clock` reads a specified time—and then completes.
+    public struct AbsoluteChime<Unit>: Publisher where Unit: Time.Unit {
         
         public typealias Output = Absolute<Unit>
         public typealias Failure = Never
         
         /// The clock that the publisher watches for time events.
-        public let clock: Clock
-        public let value: Absolute<Unit>
+        public var clock: Clock
         
-        init(for clock: Clock, atFirstInstantOf value: Absolute<Unit>) {
+        /// The time at which to chime.
+        public var value: Absolute<Unit>
+        
+        public init(for clock: Clock, firstInstantOf value: Absolute<Unit>) {
             self.clock = clock
             self.value = value
         }

--- a/Sources/Time/3. Clock/Clock+Chimes.swift
+++ b/Sources/Time/3. Clock/Clock+Chimes.swift
@@ -1,0 +1,162 @@
+//
+//  Clock+Chimes.swift
+//  Time
+//
+//  Created by James Robinson on 4/11/20.
+//
+
+#if canImport(Combine)
+import Foundation
+import Dispatch
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Clock {
+    
+    /// Sets up a repeating chime (ex: "every 5 minutes"), optionally starting at a time other than the present instant.
+    ///
+    /// - Parameters:
+    ///   - interval: The amount of time that should elapse before the next chime occurs.
+    ///   - startTime: The time to start counting at before the first chime occurs.
+    /// - Returns: A publisher which publishes absolute time values at the moment of each chime.
+    public func chime<S, L>(every interval: Difference<S, L>,
+                            startingFrom startTime: Absolute<S>? = nil) -> Clock.IntervalChime<S> where S: Unit, L: Unit {
+        return Clock.IntervalChime<S>(clock: self)
+    }
+    
+    /// Sets up a repeating chime for each unit that matches the given closure.
+    ///
+    /// For example:
+    /// ```
+    /// // Chimes every hour at *:00, *:13, *:26, *:39, *:52
+    /// clock.chime(when: { (time: Absolute<Minute>) in
+    ///     time.minute % 13 == 0
+    /// })
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - matches: A closure which is called when each prospective unit elapses to determine
+    ///   whether it should be published.
+    ///   - time: A propspective time value.
+    ///
+    /// - Returns: A publisher which publishes absolute time values at the moment of each chime.
+    public func chime<U: Unit>(when matches: @escaping (_ time: Absolute<U>) -> Bool) -> AnyPublisher<Absolute<U>, Never> {
+        let startTime: Absolute<U> = self.this()
+        let interval = Difference<U, Era>(value: 1, unit: U.component)
+        return chime(every: interval, startingFrom: startTime)
+           .filter(matches)
+           .eraseToAnyPublisher()
+    }
+    
+    /// Sets up a single chime (ex: "at 12:00 PM").
+    ///
+    /// Useful, for example, when you want the `Clock` to "tell me when it's 3:00 PM."
+    ///
+    /// - Parameter time: The time at which the chime should occur.
+    ///
+    /// - Returns: A publisher which publishes the current absolute time and then completes.
+    public func chime<U>(at time: Absolute<U>) -> Clock.AbsoluteChime<U> where U: Unit {
+        return Clock.AbsoluteChime<U>(for: self, atFirstInstantOf: time)
+    }
+    
+}
+
+// MARK: - Interval Chime
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Clock {
+    
+    public struct IntervalChime<Unit>: Combine.Publisher where Unit: Time.Unit {
+        
+        public typealias Output = Absolute<Unit>
+        public typealias Failure = Never
+        
+        /// The clock that the publisher watches for time events.
+        public let clock: Clock
+        
+        public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+            _ = subscriber.receive(clock.this())
+        }
+        
+    }
+}
+
+// MARK: - Absolute Chime
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Clock {
+    
+    public final class AbsoluteChimeSubscription<SubscriberType, SmallestUnit>: Combine.Subscription
+        where SmallestUnit: Unit,
+        SubscriberType: Subscriber,
+        SubscriberType.Failure == Clock.AbsoluteChime<SmallestUnit>.Failure,
+        SubscriberType.Input == Clock.AbsoluteChime<SmallestUnit>.Output {
+        
+        private var subscriber: SubscriberType?
+        private let clock: Clock
+        private let value: Absolute<SmallestUnit>
+        private let timer: DispatchSourceTimer
+        
+        init(subscriber: SubscriberType, clock: Clock, value: Absolute<SmallestUnit>) {
+            self.subscriber = subscriber
+            self.clock = clock
+            self.value = value
+            
+            // start waiting...
+            self.timer = DispatchSource.makeTimerSource(flags: .strict)
+            timer.setEventHandler(handler: performChime)
+            let now: Absolute<SmallestUnit> = clock.this()
+            let then = value
+            let nowSeconds = now.firstInstant.intervalSinceEpoch.rawValue
+            let thenSeconds = then.firstInstant.intervalSinceEpoch.rawValue
+            
+            let rate = clock.rate
+            let difference = (thenSeconds - nowSeconds) / rate
+            timer.schedule(deadline: .now() + difference)
+            timer.activate()
+        }
+        
+        private func performChime() {
+            _ = subscriber?.receive(clock.this())
+            subscriber?.receive(completion: .finished)
+            subscriber = nil
+        }
+        
+        public func request(_ demand: Subscribers.Demand) {
+            // We ignore this, since time doesn't care when we're looking.
+        }
+        
+        public func cancel() {
+            timer.cancel()
+            subscriber = nil
+        }
+    }
+    
+    /// A publisher which fires exactly once and then completes.
+    public struct AbsoluteChime<Unit>: Combine.Publisher where Unit: Time.Unit {
+        
+        public typealias Output = Absolute<Unit>
+        public typealias Failure = Never
+        
+        /// The clock that the publisher watches for time events.
+        public let clock: Clock
+        public let value: Absolute<Unit>
+        
+        init(for clock: Clock, atFirstInstantOf value: Absolute<Unit>) {
+            self.clock = clock
+            self.value = value
+        }
+        
+        public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+            let subscription =
+                AbsoluteChimeSubscription(
+                    subscriber: subscriber,
+                    clock: clock,
+                    value: value)
+            subscriber.receive(subscription: subscription)
+        }
+        
+    }
+    
+}
+#endif

--- a/Sources/Time/3. Clock/Clock.swift
+++ b/Sources/Time/3. Clock/Clock.swift
@@ -19,6 +19,11 @@ public class Clock {
     
     private let impl: ClockImplementation
     
+    /// How many seconds the `Clock` measures per actual second elapsed.
+    ///
+    /// This value is 1.0, unless otherwise specified in the initializer.
+    public var rate: Double { impl.SISecondsPerActualSecond }
+    
     /// The `Clock`'s `Region`.
     public let region: Region
     

--- a/Sources/Time/3. Clock/ClockImplementation.swift
+++ b/Sources/Time/3. Clock/ClockImplementation.swift
@@ -16,12 +16,14 @@ internal extension Instant {
 
 internal protocol ClockImplementation {
     var SISecondsPerCalendarSecond: Double { get }
+    var SISecondsPerActualSecond: Double { get }
     func now() -> Instant
     
 }
 
 internal struct SystemClock: ClockImplementation {
     let SISecondsPerCalendarSecond: Double = 1.0
+    let SISecondsPerActualSecond: Double = 1.0
     func now() -> Instant { return Instant() }
 }
 
@@ -32,6 +34,7 @@ internal struct CustomClock: ClockImplementation {
     let rate: Double
     let calendar: Calendar
     var SISecondsPerCalendarSecond: Double { return calendar.SISecondsPerSecond }
+    var SISecondsPerActualSecond: Double { return rate * SISecondsPerCalendarSecond }
     
     private let actualRate: Double
     
@@ -56,6 +59,7 @@ internal struct OffsetClock: ClockImplementation {
     let base: ClockImplementation
     let offset: TimeInterval
     var SISecondsPerCalendarSecond: Double { return base.SISecondsPerCalendarSecond }
+    var SISecondsPerActualSecond: Double { SISecondsPerCalendarSecond }
     
     init(offset: TimeInterval, from base: ClockImplementation) {
         self.base = base

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,4 +8,7 @@ XCTMain([
     testCase(RegionTests.allTests),
     testCase(RelationTests.allTests),
     testCase(TimeTests.allTests),
+    #if canImport(Combine)
+    testCase(ClockChimeTests.allTests)
+    #endif
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,7 +8,4 @@ XCTMain([
     testCase(RegionTests.allTests),
     testCase(RelationTests.allTests),
     testCase(TimeTests.allTests),
-    #if canImport(Combine)
-    testCase(ClockChimeTests.allTests)
-    #endif
 ])

--- a/Tests/TimeTests/ClockChimeTests.swift
+++ b/Tests/TimeTests/ClockChimeTests.swift
@@ -1,0 +1,112 @@
+//
+//  ClockChimeTests.swift
+//  TimeTests
+//
+//  Created by James Robinson on 4/11/20.
+//
+
+import XCTest
+import Combine
+import Time
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ClockChimeTests: XCTestCase {
+    
+    static var allTests: [(String, (ClockChimeTests) -> () throws -> ())] = [
+        ("testImmediateChime", testImmediateChime),
+        ("testChimeAtSpecificValue", testChimeAtSpecificValue),
+        ("testScaledChimeAtSpecificValue", testScaledChimeAtSpecificValue),
+    ]
+    
+    var clock: Clock!
+    
+    override func setUp() {
+        clock = Clock()
+    }
+    
+    func testImmediateChime() {
+        let chimesOnce = expectation(description: "Clock chimes in just two seconds")
+        let completes = expectation(description: "Chime completes")
+        let now = clock.thisNanosecond()
+        
+        var observation: AnyCancellable? = clock
+            .chime(at: now)
+            .sink(
+                receiveCompletion: { (completion) in
+                    completes.fulfill()
+                },
+                receiveValue: { (result) in
+                    XCTAssertEqual(result.firstInstant.intervalSinceEpoch.rawValue,
+                                   now.firstInstant.intervalSinceEpoch.rawValue,
+                                   accuracy: 0.005)
+                    XCTAssertEqual(result.absoluteSecond,
+                                   now.absoluteSecond)
+                    chimesOnce.fulfill()
+                }
+            )
+        
+        wait(for: [chimesOnce, completes], timeout: 0.5, enforceOrder: true)
+        if observation != nil { // Otherwise, the observer deallocates early, and cancels!
+            observation = nil
+        }
+    }
+    
+    func testChimeAtSpecificValue() {
+        let chimesOnce = expectation(description: "Clock chimes in just two seconds")
+        let completes = expectation(description: "Chime completes")
+        let seconds: Int = 2
+        let xSecondsFromNow = clock.thisNanosecond().adding(seconds: seconds)
+        
+        var observation: AnyCancellable? = clock
+            .chime(at: xSecondsFromNow)
+            .sink(
+                receiveCompletion: { (completion) in
+                    completes.fulfill()
+                },
+                receiveValue: { (result) in
+                    XCTAssertEqual(result.firstInstant.intervalSinceEpoch.rawValue,
+                                   xSecondsFromNow.firstInstant.intervalSinceEpoch.rawValue,
+                                   accuracy: 0.005)
+                    XCTAssertEqual(result.absoluteSecond,
+                                   xSecondsFromNow.absoluteSecond)
+                    chimesOnce.fulfill()
+                }
+            )
+        
+        wait(for: [chimesOnce, completes], timeout: Double(seconds) + 0.5, enforceOrder: true)
+        if observation != nil { // Otherwise, the observer deallocates early, and cancels!
+            observation = nil
+        }
+    }
+    
+    func testScaledChimeAtSpecificValue() {
+        let chimesOnce = expectation(description: "Clock chimes in just two seconds")
+        let completes = expectation(description: "Chime completes")
+        let seconds: Int = 2
+        let rate: Double = 2.0
+        let clock = Clock(startingFrom: .reference, rate: rate)
+        let xScaledSeconds = clock.thisNanosecond().adding(seconds: seconds)
+        
+        var observation: AnyCancellable? = clock
+            .chime(at: xScaledSeconds)
+            .sink(
+                receiveCompletion: { (completion) in
+                    completes.fulfill()
+                },
+                receiveValue: { (result) in
+                    XCTAssertEqual(result.firstInstant.intervalSinceEpoch.rawValue,
+                                   xScaledSeconds.firstInstant.intervalSinceEpoch.rawValue,
+                                   accuracy: 0.01) // Accuracy is a tad screwy with scaled seconds
+                    XCTAssertEqual(result.absoluteSecond,
+                                   xScaledSeconds.absoluteSecond)
+                    chimesOnce.fulfill()
+                }
+            )
+        
+        wait(for: [chimesOnce, completes], timeout: 1.5, enforceOrder: true)
+        if observation != nil { // Otherwise, the observer deallocates early, and cancels!
+            observation = nil
+        }
+    }
+    
+}

--- a/Tests/TimeTests/ClockChimeTests.swift
+++ b/Tests/TimeTests/ClockChimeTests.swift
@@ -5,6 +5,7 @@
 //  Created by James Robinson on 4/11/20.
 //
 
+#if canImport(Combine)
 import XCTest
 import Combine
 import Time
@@ -17,7 +18,8 @@ final class ClockChimeTests: XCTestCase {
         ("testImmediateChime", testImmediateChime),
         ("testChimeAtSpecificPeriod", testChimeAtSpecificPeriod),
         ("testScaledChimeAtSpecificPeriod", testScaledChimeAtSpecificPeriod),
-        ("testAbsoluteChimeCancel", testAbsoluteChimeCancel),
+        ("testSingleChimeCancel", testSingleChimeCancel),
+        
         ("testIntervalChime", testIntervalChime),
         ("testIntervalChimeOnce", testIntervalChimeOnce),
         ("testIntervalChimeAfterDelay", testIntervalChimeAfterDelay),
@@ -148,7 +150,7 @@ final class ClockChimeTests: XCTestCase {
         }
     }
     
-    func testAbsoluteChimeCancel() {
+    func testSingleChimeCancel() {
         let distantFuture = Absolute<Second>(region: .posix, date: .distantFuture)
         let chime = clock.chime(at: distantFuture).sink { (result) in
             XCTFail("We shouldn't get a chime from the distant future: \(result)")
@@ -289,3 +291,4 @@ final class ClockChimeTests: XCTestCase {
     }
     
 }
+#endif


### PR DESCRIPTION
Added chimes feature, as per discussion in #18.

Could perhaps use some more unit tests, but I built only what I had tests for (took a stab at TDD).

If a client platform can import `Combine`, then relevant methods are made available on the `Clock` interface for observing when specific times or time intervals elapse.