### PR TITLE
Convert Absolute timeperiod storage to new style on decoding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         image: 
-          - "swift:5.1"
+          - "swift:5.7.2"
     name: Linux
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
The new `Codable` implementation was giving me unusable `Absolute<U>` instances when loading from values serialised with older commits. 

This PR converts the old storage style to the new one on decoding. 