### PR TITLE
Conform various types to `Sendable`

### DIFF
--- a/Sources/Time/10-Relations/Relations.swift
+++ b/Sources/Time/10-Relations/Relations.swift
@@ -6,7 +6,7 @@ import Foundation
 /// This set of possibilities is entirely encapsulated by the `Relation` enum.
 ///
 /// - SeeAlso: [Allen's Interval Algebra](https://en.wikipedia.org/wiki/Allen%27s_interval_algebra)
-public enum Relation: Hashable, CaseIterable {
+public enum Relation: Hashable, CaseIterable, Sendable {
     
     internal static let meetings: Set<Relation> = [.meets, .isMetBy, .starts, .isStartedBy, .finishes, .isFinishedBy]
     internal static let overlappings: Set<Relation> = [.overlaps, .isOverlappedBy, .during, .contains, .equal]

--- a/Sources/Time/11-Rounding/Fixed+Rounding.swift
+++ b/Sources/Time/11-Rounding/Fixed+Rounding.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// An enum describing the direction to perform a rounding calculation
-public enum RoundingDirection {
-    
+public enum RoundingDirection: Sendable {
+
     /// Perform a rounding calculation such that the rounded value is preferred to be forward in time
     case forward
     
-    /// Perform a rounding calcuation such that the rounded value is preferred to be backwards in time
+    /// Perform a rounding calculation such that the rounded value is preferred to be backwards in time
     case backward
     
     /// Perform a rounding calculation towards the closer of two forwards and backwards values

--- a/Sources/Time/4-Fixed Values/Fixed.swift
+++ b/Sources/Time/4-Fixed Values/Fixed.swift
@@ -19,7 +19,7 @@ import Foundation
 /// and some methods and properties may slightly alter their behavior and semantics depending on their receiver's specified unit.
 ///
 /// Fixed values are Equatable, Hashable, Comparable, Sendable, and Codable.
-public struct Fixed<Granularity: Unit & LTOEEra> {
+public struct Fixed<Granularity: Unit & LTOEEra>: Sendable {
     
     /// The set of `Calendar.Components` represented by this particular `Fixed` value
     internal static var representedComponents: Set<Calendar.Component> {

--- a/Sources/Time/5-Differences/TimeDifference.swift
+++ b/Sources/Time/5-Differences/TimeDifference.swift
@@ -7,7 +7,7 @@ import Foundation
 /// - Parameter MinimumGranularity: The smallest representable ``Unit`` expressed in this time difference.
 /// - Parameter MaximumGranularity: The largest represesntable ``Unit`` expressed in this time difference.
 ///
-public struct TimeDifference<MinimumGranularity: Unit, MaximumGranularity: Unit> {
+public struct TimeDifference<MinimumGranularity: Unit, MaximumGranularity: Unit>: Sendable {
     internal let dateComponents: DateComponents
     
     internal init(_ dateComponents: DateComponents) {

--- a/Sources/Time/8-Formatting/FixedFormat.swift
+++ b/Sources/Time/8-Formatting/FixedFormat.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type that encapsulates the information necessary to format a fixed value
-internal struct FixedFormat<Granularity: Unit & LTOEEra> {
+internal struct FixedFormat<Granularity: Unit & LTOEEra>: Sendable {
     
     internal let configuration: FormatConfiguration
     

--- a/Sources/Time/8-Formatting/FormatTemplates.swift
+++ b/Sources/Time/8-Formatting/FormatTemplates.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type for defining template patterns used when formatting fixed values
-public struct Template<Unit>: Equatable, Format {
+public struct Template<Unit>: Equatable, Format, Sendable {
     internal let template: String
     internal init(_ template: String) {
         self.template = template

--- a/Sources/Time/Internals/DateFormatterCache.swift
+++ b/Sources/Time/Internals/DateFormatterCache.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal enum FormatConfiguration: Hashable {
+internal enum FormatConfiguration: Hashable, Sendable {
     case template(String)
     case raw(String)
     case styles(DateFormatter.Style, DateFormatter.Style)


### PR DESCRIPTION
I was getting some warnings attempting to make some types conform to Sendable in my project. `@preconcurrency import Time` is a workaround, but this was an easy enough change to make.